### PR TITLE
Fix `_hideDetailViewController` not being reset properly

### DIFF
--- a/HarmonyPatches/UI/BottomUI.cs
+++ b/HarmonyPatches/UI/BottomUI.cs
@@ -17,6 +17,16 @@ namespace BetterSongList.HarmonyPatches.UI {
 			SharedCoroutineStarter.instance.StartCoroutine(InitDelayed(__instance.transform));
 		}
 
+		static void Postfix(ref bool ____hideDetailViewController) {
+			// This doesn't get reset properly in the original method and causes a race condition that doesn't dismiss view controllers properly on the level end screen if
+			// a) a song is automatically selected by BSL when coming from the main menu
+			// b) the active tab is a non-level-pack tab (i.e. favorites or all songs)
+			// c) a view controller is presented on the level end screen (e.g. by BeatSaviorData)
+			// This causes ClearChildViewControllers to be called too early and eventually HMUI.Screen.SetRootViewController gets called twice
+			// in a row for the same screen so TransitionCoroutine doesn't have the time to complete and disable the previous view controller.
+			____hideDetailViewController = false;
+		}
+
 		// Levelnav is kinda too far down in 1.18
 		static IEnumerator FixPos(Transform t) {
 			yield return new WaitForEndOfFrame();


### PR DESCRIPTION
`_hideDetailViewController` doesn't get reset properly in `LevelCollectionNavigationController.DidActivate` and causes a race condition that doesn't dismiss view controllers properly on the level end screen if:

1. a song is automatically selected by BSL when coming from the main menu
2. the active tab is a non-level-pack tab (i.e. favorites or all songs)
3. a view controller is presented on the level end screen's right pane (e.g. by BeatSaviorData)

This causes `ClearChildViewControllers` to be called too early and eventually `HMUI.Screen.SetRootViewController` gets called twice in a row for the same screen, which in turn causes `TransitionCoroutine` to be cancelled so the previous view controller (i.e. the leaderboard) is never dismissed/disabled.

Basically, this is a fix for this issue:
![image](https://github.com/nicoco007/BeatSaber_BetterSongList/assets/1349975/3d2aeb1b-727f-4a95-9b23-088ecc162017)
